### PR TITLE
Merge: 달력, 일정 추가 페이지 ui 사이즈 및 규격 수정

### DIFF
--- a/feature/feature-home/src/main/java/com/comit/feature_home/screen/WriteClosedDayScreen.kt
+++ b/feature/feature-home/src/main/java/com/comit/feature_home/screen/WriteClosedDayScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
@@ -69,8 +68,6 @@ import kotlinx.coroutines.launch
 import java.sql.Date
 import java.util.Calendar
 import java.util.GregorianCalendar
-
-private val HomeCalendarHeight: Dp = 422.dp
 
 @Stable
 private val CalendarPadding = PaddingValues(
@@ -308,7 +305,6 @@ fun WriteClosedDayScreen(
                 statusName = SimTongCalendarStatus.WRITTEN,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(HomeCalendarHeight)
                     .padding(CalendarPadding),
                 refresh = refresh
             )

--- a/feature/feature-home/src/main/java/com/comit/feature_home/screen/schedule/WriteScheduleScreen.kt
+++ b/feature/feature-home/src/main/java/com/comit/feature_home/screen/schedule/WriteScheduleScreen.kt
@@ -168,7 +168,6 @@ fun WriteScheduleScreen(
                 onDismissRequest = { timerDialogVisible = false },
                 onBtnClick = { vm.inputAlarm(it) },
             )
-            
             Spacer(modifier = Modifier.height(8.dp))
 
             SimTongBtnField(

--- a/feature/feature-home/src/main/java/com/comit/feature_home/screen/schedule/WriteScheduleScreen.kt
+++ b/feature/feature-home/src/main/java/com/comit/feature_home/screen/schedule/WriteScheduleScreen.kt
@@ -168,6 +168,8 @@ fun WriteScheduleScreen(
                 onDismissRequest = { timerDialogVisible = false },
                 onBtnClick = { vm.inputAlarm(it) },
             )
+            
+            Spacer(modifier = Modifier.height(8.dp))
 
             SimTongBtnField(
                 onClick = { timerDialogVisible = true },


### PR DESCRIPTION
## 개요
- 휴무표 작성이랑 메인에 있는 캘린더 크기를 같게 맞춤
- 일정 수정 페이지 뷰의 간격이 맞도록 수정
- https://limsaehyun.atlassian.net/browse/SIMT-116?atlOrigin=eyJpIjoiNjZiZTM4N2I0YjMzNDllYjk1NmQ1MzcxY2M4OTk5MDkiLCJwIjoiaiJ9

[SIMT-116]: https://limsaehyun.atlassian.net/browse/SIMT-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ